### PR TITLE
Smoke tests for Crypt::Image module based on sparrow crypt-image-smoke  plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: "perl"
+perl:
+  - "5.20"
+
+install:
+    - cpanm Sparrow
+    - sparrow plg install crypt-image-smoke
+
+script: "cpanm . && sparrow plg run crypt-image-smoke"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: "perl"
+
 perl:
   - "5.20"
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libgd-dev
 
 install:
     - cpanm --notest -q Sparrow

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ perl:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libgd-dev
+  - sudo apt-get install -y libgd2-noxpm-dev
 
 install:
     - cpanm --notest -q Sparrow

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ perl:
 
 install:
     - cpanm Sparrow
-    - sparrow plg install crypt-image-smoke
+    - sparrow plg install crypt-image-smoke 
 
 script: "cpanm . && sparrow plg run crypt-image-smoke"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ perl:
   - "5.20"
 
 install:
-    - cpanm Sparrow
+    - cpanm --notest -q Sparrow
     - sparrow plg install crypt-image-smoke 
 
 script: "cpanm . && sparrow plg run crypt-image-smoke"


### PR DESCRIPTION
Hi Mohammad! This is simple smoke tests for your Crypt::Image module, example Travis job is here - https://travis-ci.org/melezhik/Crypt-Image/builds/180518462 

There are actually 2 tests here but made in sparrow ( black box testing ) manner:
1. create a crypted image file and then decrypt it and check if we get required string in ( /modules/decrypt case )
2. create a crypted image file and check if it differ from original by issuing `diff` command  

The source code of  crypt-image-smoke sparrow plugin could be found here - https://github.com/melezhik/crypt-image-smoke , actually it is very simple to understand ( just a couple of bash scripts )

